### PR TITLE
Removed "obj" from offsets keys

### DIFF
--- a/src/hal/helpers/tcc.py
+++ b/src/hal/helpers/tcc.py
@@ -274,7 +274,7 @@ class TCCHelper(HALHelper):
             raise HALError("Some axes are not clear. Cannot continue.")
 
         # NOTE: TBD: We should limit which offsets are kept.
-        keep_args = "/keep=(obj,arc,gcorr,calib,bore)" if keep_offsets else ""
+        keep_args = "/keep=(arc,gcorr,calib,bore)" if keep_offsets else ""
         rotwrap = f"/rotwrap={rotwrap}" if rotwrap else ""
 
         slew_cmd = None


### PR DESCRIPTION
To fix the keep offsets button in Boson, we need to remove "obj" from the list of tcc /keep keywords. Obj is referring to object arcOffset, but the key is just arcOffset, or arc, which is already present.